### PR TITLE
Match stops when leaving pong page

### DIFF
--- a/srcs/containers/django/src/pong/static/js/classes/Game.js
+++ b/srcs/containers/django/src/pong/static/js/classes/Game.js
@@ -78,6 +78,13 @@ class Game {
 		this.ball.addAudio(this.audio);
 	}
 
+    stopMatch() {
+        this.running = false;
+        this.ball.resetBall();
+        this.match = null;
+        this.tournament = null;
+    }
+
 	// These are the modes bound to the buttons in the menu
 	async startSolo() {
 		this.mode = 'solo';

--- a/srcs/containers/django/src/pong/static/js/loadPage.js
+++ b/srcs/containers/django/src/pong/static/js/loadPage.js
@@ -5,10 +5,13 @@ function loadPageClosure(game) {
 	return async (page) => {
 		console.log("loading page :", page);
 		if (game.audio && page != 'pong') {
-			game.audio.playSound(game.audio.select_1);
+            game.audio.playSound(game.audio.select_1);
 		}
 		try {
-			const mainContent = document.getElementById('main-content');
+            if (page !== 'pong') {
+                game.stopMatch();
+            }
+            const mainContent = document.getElementById('main-content');
 			const underTitle = document.getElementById('under-title');
 			
 			if (underTitle) {
@@ -29,7 +32,8 @@ function loadPageClosure(game) {
 			// Use pushState if it's a new page, otherwise use replaceState
             const state = { page: page };
             if (location.hash !== `#${page}`) {
-                history.pushState(state, "", `#${page}`);
+                if (page !== 'pong')
+                    history.pushState(state, "", `#${page}`);
             } else {
                 history.replaceState(state, "", `#${page}`);
             }
@@ -46,6 +50,7 @@ function loadPageClosure(game) {
 				// document.getElementById('lastModified').textContent = new Date(document.lastModified).toLocaleString();
 				dropDownEventListeners(game);
 			}
+
 			
 		} catch (error) {
 			console.error('Error loading page:', error);


### PR DESCRIPTION
When leaving the pong page, match stops. Also, pong is not added to pushState so you cannot forward to it. This solves some problems that we had with forwarding to a match that already started.

There is a problem at the moment with registering a new user and logging in with a known user. But this is unrelated to these changes.